### PR TITLE
Fixed to make this work with Phabricator's new PHIDs

### DIFF
--- a/includes/class.phabricatorexport.php
+++ b/includes/class.phabricatorexport.php
@@ -19,16 +19,15 @@ class PhabricatorExport	{
 		$query = 'SELECT * FROM phriction_document ORDER BY depth ASC';
 		$rows = $this->db->query($query);
 		$rows->setFetchMode(PDO::FETCH_ASSOC);
-
 		$return = array();
 		while($row = $rows->fetch()) {
-			$return[] = $this->getDocument($row['id']);
+			$return[] = $this->getDocument($row['contentPHID']);
 		}
 		return $return;
 	}
 
-	public function getDocument($id) {
-		$query = sprintf('SELECT * FROM phriction_content WHERE documentID = %d ORDER BY version DESC LIMIT 1', $id);
+	public function getDocument($phid) {
+		$query = sprintf('SELECT * FROM phriction_content WHERE phid = "%s" ORDER BY version DESC LIMIT 1', $phid);
 		$row = $this->db->query($query);
 		$row->setFetchMode(PDO::FETCH_CLASS, 'PhrictionDoc');
 		return $row->fetch();


### PR DESCRIPTION
Phabricator abandoned the numeric ID system that this code relied on and introduced binary PHIDs. This PR fixes this code to make it work with modern Phriction DBs.